### PR TITLE
Do retries if the API fails

### DIFF
--- a/src/DR/PSDB/PSDBClient.php
+++ b/src/DR/PSDB/PSDBClient.php
@@ -4,6 +4,9 @@ namespace DR\PSDB;
 
 class PSDBClient {
 
+	const RETRY_TIME = 30;
+	const MAX_ATTEMPTS = 10;
+
 	/** @var string */
 	protected $_baseUrl;
 
@@ -44,8 +47,29 @@ class PSDBClient {
     // Set the URL
     curl_setopt($this->_curlHandle, CURLOPT_URL, $url);
 
-    // Fetch the website.
-    $result = curl_exec($this->_curlHandle);
+    // The API can be somewhat unstable in case we don't get a JSON
+    // result we wait and try again (usually errors still has a 200 OK
+    // but content type is `text/html`). We'll loop over a number of
+    // attempts.
+    for ($attempt = 0; $attempt < self::MAX_ATTEMPTS; $attempt++) {
+        // Fetch the website.
+        $result = curl_exec($this->_curlHandle);
+
+        $info = curl_getinfo($this->_curlHandle);
+
+        // If we didn't succeed, continue with next try.
+        if (($info['http_code'] != 200) || (substr($info['content_type'], 0, 16) != 'application/json')) {
+            $duration = $attempt * self::RETRY_TIME;
+            echo "Error in response. Retrying after {$duration} seconds...\n";
+            sleep($duration);
+
+            // Continue with next iteration.
+            continue;
+        }
+
+        // We succeeded so break out of the loop.
+        break;
+    }
 
     if ($result === false) {
         throw new \RuntimeException("Error from the PSDB webservice ($url): " . curl_error($this->_curlHandle));


### PR DESCRIPTION
The "low budget" logging with `echo` is how it's done elsewhere in this class.

Currently the API is extremely unreliable. We'll just retry with a greater and greater interval (and pray it works -- or they fix it on the PSDB side).